### PR TITLE
Change to webpack emit instead of direct write.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can configure your compilation with additional parameters:
     },
     target: {
       name: 'index.html',
-      dir: './public'
+      dir: 'views/'
     },
     parameters: {
       title: 'my site title',

--- a/index.js
+++ b/index.js
@@ -3,53 +3,63 @@ var fs = require('fs');
 var ejs = require('ejs');
 
 function ejsBuilder(options) {
-  var files = options.files || [];
-  var root = options.root;
-
-  if (typeof root == 'undefined') {
-    root = path.join(__dirname,'../../');
-  }
-
-  files.forEach(function(file) {
-    var filename = '';
-    var compileOptions = {
-      sourceName: '',
-      sourceDir: root,
-      targetName: '',
-      targetDir: root,
-      parameters: file.parameters || {},
-      encoding: file.encoding || 'utf8',
-    };
-
-    if (typeof file == 'string') {
-      compileOptions.sourceName = file;
-      compileOptions.sourceDir = root;
-    } else if (typeof file == 'object') {
-      if (typeof file.source != 'undefined') {
-        compileOptions.sourceName = file.source.name || '';
-        compileOptions.sourceDir = file.source.dir || root;
-      }
-      if (typeof file.target != 'undefined') {
-        compileOptions.targetName = file.target.name || '';
-        compileOptions.targetDir = file.target.dir || root;
-      }
-    }
-
-    if (compileOptions.sourceName.length > 0) {
-      var sourceFile = fs.readFileSync(path.join(compileOptions.sourceDir, compileOptions.sourceName), { encoding: compileOptions.encoding });
-      var targetFile = ejs.render(sourceFile, compileOptions.parameters);
-      var targetFileName = (compileOptions.targetName.length > 0) ? compileOptions.targetName : compileOptions.sourceName.replace('.ejs','.html');
-      fs.writeFileSync(
-        path.join(compileOptions.targetDir, targetFileName),
-        targetFile
-      );
-    }
-  });
-
+	this.options = options || {};
 }
 
 ejsBuilder.prototype.apply = function(compiler) {
-  compiler.plugin('done', function(stats) {});
+	var files = this.options.files || [];
+	var root = this.options.root;
+
+	compiler.plugin('emit', function(compilation, callback) {
+		if (typeof root == 'undefined') {
+			root = path.join(__dirname,'../../');
+		}
+
+		files.forEach(function(file) {
+			var filename = '';
+			var compileOptions = {
+				sourceName: '',
+				sourceDir: root,
+				targetName: '',
+				targetDir: root,
+				parameters: file.parameters || {},
+				encoding: file.encoding || 'utf8',
+			};
+
+			if (typeof file == 'string') {
+				compileOptions.sourceName = file;
+				compileOptions.sourceDir = root;
+			} else if (typeof file == 'object') {
+				if (typeof file.source != 'undefined') {
+					compileOptions.sourceName = file.source.name || '';
+					compileOptions.sourceDir = file.source.dir || root;
+				}
+				if (typeof file.target != 'undefined') {
+					compileOptions.targetName = file.target.name || '';
+					compileOptions.targetDir = file.target.dir || '';
+				}
+			}
+
+			if (compileOptions.sourceName.length > 0) {
+				var sourceFile = fs.readFileSync(path.join(compileOptions.sourceDir, compileOptions.sourceName), { encoding: compileOptions.encoding });
+				var targetFile = ejs.render(sourceFile, compileOptions.parameters);
+				var targetFileName = (compileOptions.targetName.length > 0)
+					? (compileOptions.targetDir + compileOptions.targetName)
+				 	: compileOptions.sourceName.replace('.ejs','.html');
+				compilation.assets[targetFileName] = {
+					source: function() {
+						return targetFile;
+					},
+					size: function () {
+						return targetFile.length;
+					}
+				};
+			}
+		});
+
+		callback();
+	});
 };
 
 module.exports = ejsBuilder;
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ejs-webpack-builder",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Webpack plugin to build EJS files",
   "author": {
     "name": "Jonathan Argentiero",


### PR DESCRIPTION
Change to webpack 'emit' instead of writing directly to the filesystem. Doing it this way has the advantage that the emitted files get recognised by other plugins (e.g. [offline-plugin](https://github.com/NekR/offline-plugin)) and are listed in the webpack log.

This introduces a (breaking) change to the config options. Files now get writen to the output path set in the webpack options. The targetDir option now sets a directory in the output path and has to end with a '/' (at least for now).

Since the options related change is breaking I bumped the version to 2.0.

Closes #3 
