### PR TITLE
Path resolve

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,9 @@ ejsBuilder.prototype.apply = function(compiler) {
 			}
 
 			if (compileOptions.sourceName.length > 0) {
-				var sourceFile = fs.readFileSync(path.join(compileOptions.sourceDir, compileOptions.sourceName), { encoding: compileOptions.encoding });
+				var sourceFilePath=path.join(compileOptions.sourceDir, compileOptions.sourceName);
+				var sourceFile = fs.readFileSync(sourceFilePath, { encoding: compileOptions.encoding});
+				compileOptions.parameters.filename=sourceFilePath;
 				var targetFile = ejs.render(sourceFile, compileOptions.parameters);
 				var targetFileName = (compileOptions.targetName.length > 0)
 					? (compileOptions.targetDir + compileOptions.targetName)

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ ejsBuilder.prototype.apply = function(compiler) {
 				compileOptions.parameters.filename=sourceFilePath;
 				var targetFile = ejs.render(sourceFile, compileOptions.parameters);
 				var targetFileName = (compileOptions.targetName.length > 0)
-					? (compileOptions.targetDir + compileOptions.targetName)
+					? path.join(compileOptions.targetDir, compileOptions.targetName)
 				 	: compileOptions.sourceName.replace('.ejs','.html');
 				compilation.assets[targetFileName] = {
 					source: function() {


### PR DESCRIPTION
The thing broke down when trying to compile templates with <%include using relative paths, as ejs.render requires _filename_ option for that. Could be fixed by replacing to ejs.renderFile, but that way we would lose _encoding_ option. Also I changed output path from simple concatenation to _path.join_ as original syntax required the trailing "/" in corresponding config option and I found that behaviour less predictable